### PR TITLE
产品后台react前端bug修复

### DIFF
--- a/main/manager-web-react/index.html
+++ b/main/manager-web-react/index.html
@@ -1,3 +1,11 @@
+<!--
+ * @Author: yuyuhailian 1411102347@qq.com
+ * @Date: 2025-09-28 23:38:19
+ * @LastEditors: yuyuhailian 1411102347@qq.com
+ * @LastEditTime: 2025-09-29 14:26:11
+ * @FilePath: \manager-web-react\index.html
+ * @Description: 这是默认设置,请设置`customMade`, 打开koroFileHeader查看配置 进行设置: https://github.com/OBKoro1/koro1FileHeader/wiki/%E9%85%8D%E7%BD%AE
+-->
 <!doctype html>
 <html lang="en">
   <head>

--- a/main/manager-web-react/pnpm-workspace.yaml
+++ b/main/manager-web-react/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+onlyBuiltDependencies:
+  - '@tailwindcss/oxide'
+  - esbuild

--- a/main/manager-web-react/src/App.tsx
+++ b/main/manager-web-react/src/App.tsx
@@ -1,6 +1,5 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
-import "./App.css";
 import { AuthProvider } from "./contexts/AuthContext";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { HomePage } from "./pages/HomePage";
@@ -12,7 +11,6 @@ import { DeviceManagement } from "./pages/DeviceManagement";
 import { ModelConfigPage } from "./pages/ModelConfig";
 import { ParamsManagementPage } from "./pages/ParamsManagement";
 import AgentDetail from "./pages/AgentDetail";
-import DeviceActivationTool from "./pages/DeviceActivationTool";
 import OtaManagementPage from "./pages/OtaManagement";
 import DictManagementPage from "./pages/DictManagement";
 import ProviderManagementPage from "./pages/ProviderManagement";

--- a/main/manager-web-react/src/components/agent/ConfigTab.tsx
+++ b/main/manager-web-react/src/components/agent/ConfigTab.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, type Resolver } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 
@@ -11,9 +11,10 @@ import { motion } from "framer-motion";
 import BasicConfigCard from "@/components/agent/config/BasicConfigCard";
 import ModelSelectCard from "@/components/agent/config/ModelSelectCard";
 import PromptMemoryCard from "@/components/agent/config/PromptMemoryCard";
-import { useAgentGetAgentByIdQuery, useAgentUpdateMutation } from "@/hooks/agent/generatedHooks";
+import { useAgentGetAgentByIdQuery, useAgentListGetUserAgentsQuery, useAgentUpdateMutation } from "@/hooks/agent/generatedHooks";
+import { navigate as appNavigate } from "@/lib/navigation";
 
-const schema = z.object({
+const baseSchema = z.object({
   agentName: z.string().min(1, "请输入名称"),
   language: z
     .string()
@@ -35,14 +36,8 @@ const schema = z.object({
     .optional()
     .nullable()
     .transform((v) => v ?? ""),
-  chatHistoryConf: z
-    .union([z.number().int().nonnegative(), z.string()])
-    .transform((v) => (typeof v === "string" && v !== "" ? Number(v) : Number(v || 0)))
-    .optional(),
-  sort: z
-    .union([z.number().int().nonnegative(), z.string()])
-    .transform((v) => (typeof v === "string" && v !== "" ? Number(v) : Number(v || 0)))
-    .optional(),
+  chatHistoryConf: z.coerce.number().int().nonnegative().optional(),
+  sort: z.coerce.number().int().min(0).optional(),
   // 模型关联字段（统一以字符串形式保存，后端可接受 string/number）
   vadModelId: z
     .string()
@@ -86,13 +81,21 @@ const schema = z.object({
     .transform((v) => v ?? ""),
 });
 
-type FormValues = z.infer<typeof schema>;
+type FormValues = z.infer<typeof baseSchema>;
 
 export function ConfigTab({ agentId }: { agentId: string }) {
   const queryClient = useQueryClient();
 
   const detail = useAgentGetAgentByIdQuery({ id: agentId });
   const updateMutation = useAgentUpdateMutation();
+  const { data: agentsRes } = useAgentListGetUserAgentsQuery();
+
+  // 现有名称集合（排除当前正在编辑的智能体自身名称）
+  const existingNameSet = useMemo(() => {
+    const currentId = detail.data?.data?.id;
+    const list = (agentsRes?.data ?? []).filter(a => a.id !== currentId);
+    return new Set(list.map(a => (a.agentName ?? '').trim().toLowerCase()).filter(Boolean));
+  }, [agentsRes, detail.data?.data?.id]);
 
   const defaultValues: FormValues = useMemo(() => {
     const d = detail.data?.data;
@@ -104,14 +107,14 @@ export function ConfigTab({ agentId }: { agentId: string }) {
       summaryMemory: d?.summaryMemory ?? "",
       chatHistoryConf: d?.chatHistoryConf ?? 0,
       sort: d?.sort ?? 0,
-      vadModelId: (d?.vadModelId as any)?.toString?.() ?? "",
-      asrModelId: (d?.asrModelId as any)?.toString?.() ?? "",
-      llmModelId: (d?.llmModelId as any)?.toString?.() ?? "",
-      vllmModelId: (d?.vllmModelId as any)?.toString?.() ?? "",
-      memModelId: (d?.memModelId as any)?.toString?.() ?? "",
-      intentModelId: (d?.intentModelId as any)?.toString?.() ?? "",
-      ttsModelId: (d?.ttsModelId as any)?.toString?.() ?? "",
-      ttsVoiceId: (d?.ttsVoiceId as any)?.toString?.() ?? "",
+      vadModelId: d?.vadModelId != null ? String(d.vadModelId) : "",
+      asrModelId: d?.asrModelId != null ? String(d.asrModelId) : "",
+      llmModelId: d?.llmModelId != null ? String(d.llmModelId) : "",
+      vllmModelId: d?.vllmModelId != null ? String(d.vllmModelId) : "",
+      memModelId: d?.memModelId != null ? String(d.memModelId) : "",
+      intentModelId: d?.intentModelId != null ? String(d.intentModelId) : "",
+      ttsModelId: d?.ttsModelId != null ? String(d.ttsModelId) : "",
+      ttsVoiceId: d?.ttsVoiceId != null ? String(d.ttsVoiceId) : "",
     };
   }, [detail.data]);
 
@@ -122,7 +125,7 @@ export function ConfigTab({ agentId }: { agentId: string }) {
     watch,
     setValue,
     formState: { isSubmitting },
-  } = useForm<FormValues>({ resolver: zodResolver(schema), defaultValues });
+  } = useForm<FormValues>({ resolver: zodResolver(baseSchema) as Resolver<FormValues>, defaultValues });
 
   // 同步服务端数据到表单
   useEffect(() => {
@@ -142,6 +145,16 @@ export function ConfigTab({ agentId }: { agentId: string }) {
   }, [watch, setValue])
 
   const onSubmit = async (values: FormValues) => {
+    // 重命名唯一性校验（本地校验一层，避免无谓请求）
+    const name = (values.agentName ?? '').trim().toLowerCase();
+    if (name.length < 1) {
+      toast.error('请输入名称');
+      return;
+    }
+    if (existingNameSet.has(name)) {
+      toast.error('名称已存在，请更换');
+      return;
+    }
     try {
       await updateMutation.mutateAsync({
         params: { id: agentId },
@@ -149,15 +162,26 @@ export function ConfigTab({ agentId }: { agentId: string }) {
           ...values,
           // 确保数字字段正确传递
           chatHistoryConf: Number(values.chatHistoryConf || 0),
-          sort: Number(values.sort || 0),
+          sort: Math.max(0, Number(values.sort || 0)),
         },
       });
       toast.success("保存成功");
       // 详情刷新
       await queryClient.invalidateQueries({ queryKey: ["Agent.GetAgentById"] });
+      // 使首页列表失效，返回后可自动刷新
+      await queryClient.invalidateQueries({ queryKey: ["AgentList.GetUserAgents"] });
       detail.refetch();
-    } catch (e: any) {
-      toast.error(e?.response?.data?.msg || "保存失败");
+      // 返回首页智能体列表
+      appNavigate("/home", { replace: true });
+    } catch (err: unknown) {
+      let msg: string | undefined
+      if (typeof err === 'object' && err && 'response' in err) {
+        const r = err as { response?: { data?: { msg?: string } } }
+        msg = r.response?.data?.msg
+      }
+      if (!msg && err instanceof Error) msg = err.message
+      // 如果后端返回命名冲突错误，也提示命名重复
+      toast.error(msg || '保存失败')
     }
   };
 

--- a/main/manager-web-react/src/components/agent/config/BasicConfigCard.tsx
+++ b/main/manager-web-react/src/components/agent/config/BasicConfigCard.tsx
@@ -97,7 +97,17 @@ export function BasicConfigCard({ control, setValue, watch }: Props) {
             <Controller
               control={control}
               name="sort"
-              render={({ field }) => <Input id="sort" type="number" inputMode="numeric" placeholder="越小越靠前" {...field} onChange={(e) => field.onChange(e.target.value)} />}
+              render={({ field }) => (
+                <Input
+                  id="sort"
+                  type="number"
+                  inputMode="numeric"
+                  min={0}
+                  placeholder="越小越靠前"
+                  {...field}
+                  onChange={(e) => field.onChange(Math.max(0, Number(e.target.value ?? 0)))}
+                />
+              )}
             />
           </div>
         </div>

--- a/main/manager-web-react/src/components/auth/CaptchaInput.tsx
+++ b/main/manager-web-react/src/components/auth/CaptchaInput.tsx
@@ -51,6 +51,8 @@ export const CaptchaInput: React.FC<CaptchaInputProps> = ({
             type="text" 
             placeholder="请输入验证码" 
             className="pl-10 h-11 border-input focus:border-primary focus:ring-2 focus:ring-primary/20 transition-all duration-200" 
+            aria-invalid={!!error}
+            aria-describedby={error ? `${register.name}-error` : undefined}
             disabled={disabled} 
           />
         </div>
@@ -72,7 +74,9 @@ export const CaptchaInput: React.FC<CaptchaInputProps> = ({
           )}
         </div>
       </div>
-      {error && <p className="text-sm text-destructive font-medium">{error.message}</p>}
+      {error && (
+        <p id={`${register.name}-error`} role="alert" className="text-sm text-destructive font-medium">{error.message}</p>
+      )}
     </div>
   );
 };

--- a/main/manager-web-react/src/components/auth/LoginForm.tsx
+++ b/main/manager-web-react/src/components/auth/LoginForm.tsx
@@ -15,21 +15,27 @@ import { Link } from 'react-router-dom';
 import { useUserLoginLoginMutation, useUserPubConfigPubConfigQuery } from '../../hooks/user/generatedHooks';
 
 // 导入子组件
-import { ErrorDisplay } from './ErrorDisplay';
 import { UsernameInput } from './UsernameInput';
 import { MobileInput } from './MobileInput';
 import { PasswordInput } from './PasswordInput';
 import { CaptchaInput } from './CaptchaInput';
 import { LoginTypeSwitch } from './LoginTypeSwitch';
 
-// 表单验证schema
-const loginSchema = z.object({
-  username: z.string().min(1, '用户名/手机号不能为空'),
-  password: z.string().min(1, '密码不能为空'),
-  captcha: z.string().min(1, '验证码不能为空'),
-  mobile: z.string().default(''),
-  areaCode: z.string().default('+86'),
-});
+// 按登录方式动态生成表单验证 schema
+const getLoginSchema = (loginType: LoginTypeValue) =>
+  z.object({
+    username:
+      loginType === LoginType.USERNAME
+        ? z.string().min(1, '用户名不能为空')
+        : z.string().optional().or(z.literal('')),
+    mobile:
+      loginType === LoginType.MOBILE
+        ? z.string().min(1, '手机号不能为空')
+        : z.string().default(''),
+    areaCode: z.string().default('+86'),
+    password: z.string().min(1, '密码不能为空'),
+    captcha: z.string().min(1, '验证码不能为空'),
+  });
 
 // type LoginFormData = z.infer<typeof loginSchema>;
 
@@ -46,12 +52,18 @@ export const LoginForm: React.FC<LoginFormProps> = ({
   const hasInitRef = React.useRef(false);
   
   // 使用新的 Hooks
-  const { applyLogin, generateCaptcha } = useAuth();
+  const { applyLogin } = useAuth();
   const { data: pubRes } = useUserPubConfigPubConfigQuery();
-  const publicConfig = (pubRes?.data as any) || {};
+  type PublicConfig = {
+    enableMobileRegister?: boolean;
+    allowUserRegister?: boolean;
+    mobileAreaList?: import('../../types/auth').MobileArea[];
+  };
+  const publicConfig = useMemo<PublicConfig>(() => {
+    return (pubRes?.data as PublicConfig) || {};
+  }, [pubRes]);
   // Captcha（统一复用自定义钩子）
   const { captchaData, captchaLoading, refreshCaptcha } = useBlobCaptcha();
-  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
   const loginMutation = useUserLoginLoginMutation();
   
   // 初始化时仅执行一次的验证码拉取
@@ -79,18 +91,23 @@ export const LoginForm: React.FC<LoginFormProps> = ({
     initCaptchaOnce();
   }, [initCaptchaOnce]);
   
-  const isLoading = useMemo(() => loginMutation.isPending || captchaLoading, [loginMutation.isPending, captchaLoading]);
-  console.log('[LoginForm] 组件渲染', { loginType, isLoading, hasCaptcha: !!captchaData });
+  // 仅在真正提交登录时展示“登录中...”。验证码刷新不应影响按钮文案/禁用状态。
+  const isSubmitting = useMemo(() => loginMutation.isPending, [loginMutation.isPending]);
+  console.log('[LoginForm] 组件渲染', { loginType, isSubmitting, captchaLoading, hasCaptcha: !!captchaData });
+
+  const schema = useMemo(() => getLoginSchema(loginType), [loginType]);
 
   const {
     register,
     handleSubmit,
     formState: { errors },
     setValue,
+    setError,
     watch,
     reset,
+    trigger,
   } = useForm({
-    resolver: zodResolver(loginSchema),
+    resolver: zodResolver(schema),
     defaultValues: {
       username: '',
       password: '',
@@ -118,15 +135,32 @@ export const LoginForm: React.FC<LoginFormProps> = ({
     
     // 刷新验证码
     refreshCaptcha();
-  }, [reset, areaCode, refreshCaptcha]);
+    // 触发一次校验以同步当前模式下的错误展示
+    setTimeout(() => trigger(), 0);
+  }, [reset, areaCode, refreshCaptcha, trigger]);
 
   // 表单提交
-  const onSubmit = useCallback(async (data: any) => {
+  type SubmitData = {
+    username?: string;
+    password: string;
+    captcha: string;
+    mobile?: string;
+    areaCode?: string;
+  };
+
+  const onSubmit = useCallback(async (data: SubmitData) => {
     console.log('[LoginForm] 表单提交', { loginType, data: { ...data, password: '***' } });
     
     try {
       // 构建登录数据
-      const loginData = {
+      const loginData: {
+        username: string;
+        password: string;
+        captcha: string;
+        captchaId: string;
+        areaCode?: string;
+        mobile?: string;
+      } = {
         username: loginType === LoginType.MOBILE ? `${data.areaCode}${data.mobile}` : data.username,
         password: data.password,
         captcha: data.captcha,
@@ -142,8 +176,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({
         }
       }
 
-      setErrorMessage(null);
-      const res: any = await loginMutation.mutateAsync({ data: loginData });
+      const res = await loginMutation.mutateAsync({ data: loginData }) as unknown as { code?: number; msg?: string; data?: { token?: string } };
       // 兼容 code/msg/data 结构
       if (res?.code === 0 && res?.data?.token) {
         const token: string = res.data.token;
@@ -153,34 +186,37 @@ export const LoginForm: React.FC<LoginFormProps> = ({
         onSuccess?.();
       } else {
         const msg = res?.msg || '登录失败，请重试';
-        setErrorMessage(msg);
         throw new Error(msg);
       }
       
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('[LoginForm] 登录失败:', error);
-      const msg = error?.response?.data?.msg || error?.message || '登录失败，请重试';
-      setErrorMessage(msg);
+      const msg = (error as { response?: { data?: { msg?: string } } ; message?: string })?.response?.data?.msg
+        || (error as { message?: string })?.message
+        || '登录失败，请重试';
       
       // 如果是验证码错误，刷新验证码
       if (msg.includes('验证码')) {
+        // 将服务端验证码错误同步到字段错误展示
+        setValue('captcha', '');
+        setError('captcha', { type: 'server', message: msg });
         refreshCaptcha();
+      } else {
+        // 非验证码错误，默认展示在密码字段下方
+        setError('password', { type: 'server', message: msg });
       }
     }
-  }, [loginType, loginMutation, onSuccess, captchaData?.captchaId, refreshCaptcha, applyLogin]);
+  }, [loginType, loginMutation, onSuccess, captchaData?.captchaId, refreshCaptcha, applyLogin, setError, setValue]);
 
   return (
     <div className={`space-y-6 ${className}`}>
-      {/* 错误信息显示 */}
-      <ErrorDisplay error={errorMessage} />
-
       <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
         {/* 用户名/手机号输入 */}
         {loginType === LoginType.USERNAME ? (
           <UsernameInput
             register={register('username')}
             error={errors.username}
-            disabled={isLoading}
+            disabled={isSubmitting}
           />
         ) : (
           <MobileInput
@@ -189,7 +225,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({
             areaCode={areaCode || '+86'}
             setValue={setValue}
             mobileAreaList={publicConfig?.mobileAreaList || []}
-            disabled={isLoading}
+            disabled={isSubmitting}
           />
         )}
 
@@ -197,7 +233,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({
         <PasswordInput
           register={register('password')}
           error={errors.password}
-          disabled={isLoading}
+          disabled={isSubmitting}
         />
 
         {/* 验证码输入 */}
@@ -206,16 +242,16 @@ export const LoginForm: React.FC<LoginFormProps> = ({
           error={errors.captcha}
           captchaData={captchaData}
           onRefreshCaptcha={refreshCaptcha}
-          disabled={isLoading}
+          disabled={isSubmitting}
         />
 
         {/* 登录按钮 */}
         <Button
           type="submit"
           className="w-full h-11 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white font-medium rounded-lg transition-all duration-200 shadow-lg hover:shadow-xl"
-          disabled={isLoading}
+          disabled={isSubmitting}
         >
-          {isLoading ? (
+          {isSubmitting ? (
             <div className="flex items-center gap-2">
               <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
               登录中...
@@ -230,7 +266,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({
           <LoginTypeSwitch
             currentLoginType={loginType}
             onLoginTypeChange={handleLoginTypeSwitch}
-            disabled={isLoading}
+            disabled={isSubmitting}
           />
         )}
 
@@ -239,8 +275,8 @@ export const LoginForm: React.FC<LoginFormProps> = ({
           {publicConfig?.allowUserRegister && (
             <Link
               to="/register"
-              aria-disabled={isLoading}
-              className={`text-primary hover:text-primary/80 font-medium transition-colors duration-200 px-2 py-1 rounded-md hover:bg-primary/5 ${isLoading ? 'pointer-events-none opacity-60' : ''}`}
+              aria-disabled={isSubmitting}
+              className={`text-primary hover:text-primary/80 font-medium transition-colors duration-200 px-2 py-1 rounded-md hover:bg-primary/5 ${isSubmitting ? 'pointer-events-none opacity-60' : ''}`}
             >
               新用户注册
             </Link>
@@ -248,8 +284,8 @@ export const LoginForm: React.FC<LoginFormProps> = ({
           {publicConfig?.enableMobileRegister && (
             <Link
               to="/retrieve-password"
-              aria-disabled={isLoading}
-              className={`text-primary hover:text-primary/80 font-medium transition-colors duration-200 px-2 py-1 rounded-md hover:bg-primary/5 ${isLoading ? 'pointer-events-none opacity-60' : ''}`}
+              aria-disabled={isSubmitting}
+              className={`text-primary hover:text-primary/80 font-medium transition-colors duration-200 px-2 py-1 rounded-md hover:bg-primary/5 ${isSubmitting ? 'pointer-events-none opacity-60' : ''}`}
             >
               忘记密码?
             </Link>

--- a/main/manager-web-react/src/components/auth/MobileInput.tsx
+++ b/main/manager-web-react/src/components/auth/MobileInput.tsx
@@ -63,10 +63,14 @@ export const MobileInput: React.FC<MobileInputProps> = ({
           type="tel" 
           placeholder="请输入手机号码" 
           className="flex-1 h-11 border-input focus:border-primary focus:ring-2 focus:ring-primary/20 transition-all duration-200" 
+          aria-invalid={!!mobileError}
+          aria-describedby={mobileError ? `${mobileRegister.name}-error` : undefined}
           disabled={disabled} 
         />
       </div>
-      {mobileError && <p className="text-sm text-destructive font-medium">{mobileError.message}</p>}
+      {mobileError && (
+        <p id={`${mobileRegister.name}-error`} role="alert" className="text-sm text-destructive font-medium">{mobileError.message}</p>
+      )}
     </div>
   );
 };

--- a/main/manager-web-react/src/components/auth/PasswordInput.tsx
+++ b/main/manager-web-react/src/components/auth/PasswordInput.tsx
@@ -35,6 +35,8 @@ export const PasswordInput: React.FC<PasswordInputProps> = ({
           type={showPassword ? "text" : "password"}
           placeholder={placeholder}
           className="pr-10 h-11 border-input focus:border-primary focus:ring-2 focus:ring-primary/20 transition-all duration-200"
+          aria-invalid={!!error}
+          aria-describedby={error ? `${register.name}-error` : undefined}
           disabled={disabled}
         />
         <button
@@ -47,7 +49,9 @@ export const PasswordInput: React.FC<PasswordInputProps> = ({
           {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
         </button>
       </div>
-      {error && <p className="text-sm text-destructive font-medium">{error.message}</p>}
+      {error && (
+        <p id={`${register.name}-error`} role="alert" className="text-sm text-destructive font-medium">{error.message}</p>
+      )}
     </div>
   );
 };

--- a/main/manager-web-react/src/components/auth/UsernameInput.tsx
+++ b/main/manager-web-react/src/components/auth/UsernameInput.tsx
@@ -1,3 +1,11 @@
+/*
+ * @Author: yuyuhailian 1411102347@qq.com
+ * @Date: 2025-09-28 23:38:19
+ * @LastEditors: yuyuhailian 1411102347@qq.com
+ * @LastEditTime: 2025-09-29 16:31:33
+ * @FilePath: \manager-web-react\src\components\auth\UsernameInput.tsx
+ * @Description: 这是默认设置,请设置`customMade`, 打开koroFileHeader查看配置 进行设置: https://github.com/OBKoro1/koro1FileHeader/wiki/%E9%85%8D%E7%BD%AE
+ */
 /**
  * 用户名输入组件
  * 用于用户名方式登录的输入字段
@@ -34,10 +42,14 @@ export const UsernameInput: React.FC<UsernameInputProps> = ({
           type="text" 
           placeholder={placeholder} 
           className="pl-10 h-11 border-input focus:border-primary focus:ring-2 focus:ring-primary/20 transition-all duration-200" 
+          aria-invalid={!!error}
+          aria-describedby={error ? `${register.name}-error` : undefined}
           disabled={disabled} 
         />
       </div>
-      {error && <p className="text-sm text-destructive font-medium">{error.message}</p>}
+      {error && (
+        <p id={`${register.name}-error`} role="alert" className="text-sm text-destructive font-medium">{error.message}</p>
+      )}
     </div>
   );
 };

--- a/main/manager-web-react/src/components/auth/VersionFooter.tsx
+++ b/main/manager-web-react/src/components/auth/VersionFooter.tsx
@@ -1,3 +1,11 @@
+/*
+ * @Author: yuyuhailian 1411102347@qq.com
+ * @Date: 2025-09-28 23:38:19
+ * @LastEditors: yuyuhailian 1411102347@qq.com
+ * @LastEditTime: 2025-09-29 11:05:22
+ * @FilePath: \manager-web-react\src\components\auth\VersionFooter.tsx
+ * @Description: 这是默认设置,请设置`customMade`, 打开koroFileHeader查看配置 进行设置: https://github.com/OBKoro1/koro1FileHeader/wiki/%E9%85%8D%E7%BD%AE
+ */
 /**
  * 版本信息底部组件（支持后台自定义首页文案）
  */
@@ -8,14 +16,41 @@ interface VersionFooterProps {
   className?: string;
 }
 
+interface HomeConfig {
+  platformName?: string | null;
+  platformSubTitle?: string | null;
+  footerText?: string | null;
+}
+
+type PublicConfigLite = {
+  beianIcpNum?: string | null;
+  beianGaNum?: string | null;
+  homeConfig?: HomeConfig | null;
+  name?: string | null;
+} | null;
+
+function sanitizeOptionalString(value: unknown): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  const text = String(value).trim();
+  if (!text) return undefined;
+  const lower = text.toLowerCase();
+  if (lower === 'null' || lower === 'undefined' || lower === 'nan') return undefined;
+  return text;
+}
+
 export const VersionFooter: React.FC<VersionFooterProps> = ({ className = '' }) => {
   const { publicConfig } = useAuth();
-  const homeConfig = (publicConfig?.homeConfig || {}) as Record<string, any>;
-  const platformName = (homeConfig.platformName || publicConfig?.name || '正解 AIoT') as string;
-  const platformSubTitle = (homeConfig.platformSubTitle || '管理平台') as string;
-  const footerText = (homeConfig.footerText || '') as string;
-  const beianIcpNum = (publicConfig as any)?.beianIcpNum as string | undefined;
-  const beianGaNum = (publicConfig as any)?.beianGaNum as string | undefined;
+  const cfg = (publicConfig ?? null) as PublicConfigLite;
+  const homeConfig: HomeConfig = (cfg?.homeConfig ?? {}) as HomeConfig;
+  const platformName = sanitizeOptionalString(homeConfig.platformName) || sanitizeOptionalString(cfg?.name) || '正解 AIoT';
+  const platformSubTitle = sanitizeOptionalString(homeConfig.platformSubTitle) || '管理平台';
+  const rawFooterText = homeConfig.footerText ?? '';
+  const rawBeianIcpNum = cfg?.beianIcpNum ?? undefined;
+  const rawBeianGaNum = cfg?.beianGaNum ?? undefined;
+
+  const footerText = sanitizeOptionalString(rawFooterText);
+  const beianIcpNum = sanitizeOptionalString(rawBeianIcpNum);
+  const beianGaNum = sanitizeOptionalString(rawBeianGaNum);
 
   return (
     <footer className={`text-center text-sm text-muted-foreground ${className}`}>

--- a/main/manager-web-react/src/components/dict/DictTypeDialog.tsx
+++ b/main/manager-web-react/src/components/dict/DictTypeDialog.tsx
@@ -1,0 +1,193 @@
+import React from 'react'
+import { useEffect, useMemo, useRef } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
+import { useToast } from '@/components/ui/use-toast'
+import { useQueryClient } from '@tanstack/react-query'
+import type { SysDictTypeVO, SysDictTypeDTO } from '@/types/openapi/admin'
+import { 
+  useAdminDictTypeSaveSave1Mutation,
+  useAdminDictTypeUpdateUpdate2Mutation,
+} from '@/hooks/admin'
+
+const DICT_TYPE_MAX_LEN = 64
+const DICT_NAME_MAX_LEN = 64
+const DICT_TYPE_PATTERN = /^[A-Za-z0-9_]+$/
+
+export interface DictTypeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  editingType?: SysDictTypeVO | undefined
+}
+
+const schema = z.object({
+  dictType: z
+    .string()
+    .trim()
+    .min(1, '字典编码为必填')
+    .max(DICT_TYPE_MAX_LEN, `字典编码长度不能超过${DICT_TYPE_MAX_LEN}字符`)
+    .regex(DICT_TYPE_PATTERN, '仅支持字母/数字/下划线，不允许中文'),
+  dictName: z
+    .string()
+    .trim()
+    .min(1, '字典名称为必填')
+    .max(DICT_NAME_MAX_LEN, `字典名称长度不能超过${DICT_NAME_MAX_LEN}字符`),
+  remark: z.string().max(200, '备注不能超过200字符').optional().or(z.literal('')),
+  sort: z.coerce.number().int('排序需为整数').min(0, '排序不能小于0').default(0),
+})
+
+type FormValues = z.infer<typeof schema>
+
+export function DictTypeDialog({ open, onOpenChange, editingType }: DictTypeDialogProps) {
+  const { toast } = useToast()
+  const queryClient = useQueryClient()
+  const isComposingRef = useRef(false)
+
+  const { register, handleSubmit, reset, formState: { errors, isSubmitting }, setValue, watch, setFocus } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { dictType: '', dictName: '', remark: '', sort: 0 },
+    mode: 'onChange',
+  })
+
+  const dictTypeVal = watch('dictType')
+  const dictNameVal = watch('dictName')
+
+  useEffect(() => {
+    if (!open) return
+    if (editingType) {
+      reset({
+        dictType: editingType.dictType || '',
+        dictName: editingType.dictName || '',
+        remark: editingType.remark || '',
+        sort: editingType.sort ?? 0,
+      })
+    } else {
+      reset({ dictType: '', dictName: '', remark: '', sort: 0 })
+    }
+  }, [open, editingType, reset])
+
+  const createMutation = useAdminDictTypeSaveSave1Mutation({
+    onSuccess: () => {
+      toast({ description: '保存成功' })
+      queryClient.invalidateQueries({ queryKey: ['AdminDictTypePage.Page1'] })
+      onOpenChange(false)
+    },
+    onError: (e: unknown) => {
+      const message = (e && typeof e === 'object' && (e as any).response?.data?.msg) || (e as any)?.message || '保存失败'
+      toast({ description: message, variant: 'destructive' })
+    },
+  })
+  const updateMutation = useAdminDictTypeUpdateUpdate2Mutation({
+    onSuccess: () => {
+      toast({ description: '修改成功' })
+      queryClient.invalidateQueries({ queryKey: ['AdminDictTypePage.Page1'] })
+      onOpenChange(false)
+    },
+    onError: (e: unknown) => {
+      const message = (e && typeof e === 'object' && (e as any).response?.data?.msg) || (e as any)?.message || '修改失败'
+      toast({ description: message, variant: 'destructive' })
+    },
+  })
+
+  const onSubmit = async (values: FormValues) => {
+    const payload: SysDictTypeDTO = {
+      id: editingType?.id,
+      dictType: values.dictType.trim(),
+      dictName: values.dictName.trim(),
+      remark: (values.remark || '').trim(),
+      sort: Number(values.sort || 0),
+    }
+    if (payload.id) {
+      await updateMutation.mutateAsync({ data: payload })
+    } else {
+      await createMutation.mutateAsync({ data: payload })
+    }
+  }
+
+  const onInvalid = (formErrors: any) => {
+    if (formErrors?.dictType) {
+      toast({ description: '字典编码仅支持字母/数字/下划线，不能包含中文', variant: 'destructive' })
+      setFocus('dictType')
+    }
+  }
+
+  const handleCompositionStart = () => { isComposingRef.current = true }
+  const handleCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>) => {
+    isComposingRef.current = false
+    const value = (e.target as HTMLInputElement).value || ''
+    if (value.length > DICT_TYPE_MAX_LEN) {
+      setValue('dictType', value.slice(0, DICT_TYPE_MAX_LEN), { shouldValidate: true, shouldDirty: true })
+    }
+  }
+
+  const pending = createMutation.isPending || updateMutation.isPending || isSubmitting
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{editingType ? '编辑字典类型' : '新增字典类型'}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit, onInvalid)} className="space-y-3">
+          <div className="space-y-2">
+            <Label htmlFor="dictType">字典编码</Label>
+            <Input
+              id="dictType"
+              {...register('dictType')}
+              onCompositionStart={handleCompositionStart}
+              onCompositionEnd={handleCompositionEnd}
+              placeholder="如: device_status"
+              autoComplete="off"
+              spellCheck={false}
+              disabled={pending}
+            />
+            <div className="flex items-center justify-between text-xs mt-1">
+              <span className="text-gray-500">仅字母/数字/下划线，不能包含中文，最长{DICT_TYPE_MAX_LEN}字符</span>
+              <span className="text-gray-500">{(dictTypeVal || '').length}/{DICT_TYPE_MAX_LEN}</span>
+            </div>
+            {errors.dictType && (
+              <div className="text-xs text-red-500 mt-1">{errors.dictType.message}</div>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="dictName">字典名称</Label>
+            <Input id="dictName" maxLength={DICT_NAME_MAX_LEN} {...register('dictName')} placeholder="如: 设备状态" disabled={pending} />
+            <div className="flex items-center justify-end text-xs mt-1">
+              <span className="text-gray-500">{(dictNameVal || '').length}/{DICT_NAME_MAX_LEN}</span>
+            </div>
+            {errors.dictName && (
+              <div className="text-xs text-red-500 mt-1">{errors.dictName.message}</div>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="typeRemark">备注</Label>
+            <Input id="typeRemark" {...register('remark')} placeholder="可选" disabled={pending} />
+            {errors.remark && (
+              <div className="text-xs text-red-500 mt-1">{errors.remark.message}</div>
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="typeSort">排序</Label>
+            <Input id="typeSort" type="number" {...register('sort', { valueAsNumber: true })} disabled={pending} />
+            {errors.sort && (
+              <div className="text-xs text-red-500 mt-1">{errors.sort.message}</div>
+            )}
+          </div>
+          <DialogFooter className="gap-2">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={pending}>取消</Button>
+            <Button type="submit" disabled={pending} onClick={() => console.log('DictType 创建/保存按钮点击', { mode: editingType ? 'edit' : 'create' })}>{editingType ? '保存' : '创建'}</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default DictTypeDialog
+
+

--- a/main/manager-web-react/src/components/home/AddAgentDialog.tsx
+++ b/main/manager-web-react/src/components/home/AddAgentDialog.tsx
@@ -1,10 +1,27 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { toast } from 'sonner';
-import { X, Bot, Plus } from 'lucide-react';
+import { Bot, Plus } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useQueryClient } from '@tanstack/react-query';
 
-import { useAgentSave1Mutation } from '../../hooks/agent/generatedHooks';
+import { useAgentListGetUserAgentsQuery, useAgentSave1Mutation } from '../../hooks/agent/generatedHooks';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '../ui/dialog';
+
+type ErrorWithResponse = {
+  response?: {
+    data?: {
+      msg?: string
+    }
+  }
+}
+
+function hasResponse(e: unknown): e is ErrorWithResponse {
+  return typeof e === 'object' && e !== null && 'response' in e
+}
 
 export interface AddAgentDialogProps {
   /** 对话框显示状态 */
@@ -27,216 +44,198 @@ export interface AddAgentDialogProps {
 export function AddAgentDialog({ open, onOpenChange, onSuccess }: AddAgentDialogProps) {
   console.log('[AddAgentDialog] 对话框状态:', open);
 
-  const [formData, setFormData] = useState({
-    agentName: '',
-    description: ''
-  });
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string>('');
-  const { mutateAsync: createAgent } = useAgentSave1Mutation();
+  const queryClient = useQueryClient();
+  const isComposingRef = useRef(false);
+  const NAME_MAX = 50;
+  const DESC_MAX = 200;
 
-  // 处理表单输入变化
-  const handleInputChange = (field: string, value: string) => {
-    setFormData(prev => ({
-      ...prev,
-      [field]: value
-    }));
-    // 清除错误信息
-    if (error) {
-      setError('');
+  // 获取已存在的智能体名称列表用于唯一性校验
+  const { data: agentsRes } = useAgentListGetUserAgentsQuery();
+  const existingNameSet = new Set(
+    (agentsRes?.data ?? [])
+      .map(a => (a.agentName ?? '').trim().toLowerCase())
+      .filter(Boolean)
+  );
+
+  const schema = z.object({
+    agentName: z
+      .string()
+      .trim()
+      .min(2, '智能体名称至少需要2个字符')
+      .max(NAME_MAX, `智能体名称不能超过${NAME_MAX}个字符`)
+      .refine((v) => !existingNameSet.has(v.toLowerCase()), '名称已存在，请更换'),
+    description: z.string().max(DESC_MAX, `描述不能超过${DESC_MAX}个字符`).optional().or(z.literal('')),
+  });
+
+  type FormValues = z.infer<typeof schema>;
+
+  const { register, handleSubmit, reset, formState: { errors, isSubmitting }, setValue, watch } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { agentName: '', description: '' },
+    mode: 'onChange',
+  });
+
+  const createMutation = useAgentSave1Mutation();
+  const [submitError, setSubmitError] = useState<string>('');
+
+  // 处理表单输入变化（合成态不限制，合成结束后再裁剪）
+  const agentName = watch('agentName');
+  const description = watch('description');
+
+  const handleCompositionStart = () => {
+    isComposingRef.current = true;
+  };
+
+  const handleCompositionEnd = (field: 'agentName' | 'description') => (
+    e: React.CompositionEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    isComposingRef.current = false;
+    const value = (e.target as HTMLInputElement | HTMLTextAreaElement).value || '';
+    const max = field === 'agentName' ? NAME_MAX : DESC_MAX;
+    if (value.length > max) {
+      const clipped = value.slice(0, max);
+      if (field === 'agentName') {
+        setValue('agentName', clipped, { shouldValidate: true, shouldDirty: true });
+      } else {
+        setValue('description', clipped, { shouldValidate: true, shouldDirty: true });
+      }
     }
   };
 
   // 重置表单
   const resetForm = () => {
-    setFormData({
-      agentName: '',
-      description: ''
-    });
-    setError('');
-    setIsLoading(false);
+    reset({ agentName: '', description: '' });
+    setSubmitError('');
   };
 
   // 处理关闭对话框
   const handleClose = () => {
-    if (!isLoading) {
+    if (!createMutation.isPending && !isSubmitting) {
       resetForm();
       onOpenChange(false);
     }
   };
 
   // 处理表单提交
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    
-    // 表单验证
-    if (!formData.agentName.trim()) {
-      setError('请输入智能体名称');
-      return;
-    }
-
-    if (formData.agentName.trim().length < 2) {
-      setError('智能体名称至少需要2个字符');
-      return;
-    }
-
-    setIsLoading(true);
-    setError('');
-
+  const onSubmit = async (values: FormValues) => {
+    setSubmitError('');
     try {
-      console.log('[AddAgentDialog] 提交表单数据:', formData);
-
-      const response = await createAgent({
+      console.log('[AddAgentDialog] 提交表单数据:', values);
+      const response = await createMutation.mutateAsync({
         data: {
-          agentName: formData.agentName.trim(),
+          agentName: values.agentName.trim(),
         },
       });
 
       if (!response || response.code !== 0) {
         const message = response?.msg || '添加智能体失败，请重试';
         console.warn('[AddAgentDialog] 智能体添加失败:', message);
-        setError(message);
+        setSubmitError(message);
         toast.error(message);
-        setIsLoading(false);
         return;
       }
 
+      await queryClient.invalidateQueries({ queryKey: ['AgentList.GetUserAgents'] });
       console.log('[AddAgentDialog] 智能体添加成功');
       toast.success('智能体创建成功');
       resetForm();
       await Promise.resolve(onSuccess());
     } catch (err) {
       console.error('[AddAgentDialog] 添加智能体失败:', err);
-      const message = (err as any)?.response?.data?.msg
+      const message = (hasResponse(err) && err.response?.data?.msg)
         || (err instanceof Error ? err.message : '')
         || '添加智能体失败，请重试';
-      setError(message);
+      setSubmitError(message);
       toast.error(message);
-      setIsLoading(false);
     }
   };
 
-  // 对话框未打开时不渲染
-  if (!open) {
-    return null;
-  }
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      {/* 遮罩层 */}
-      <div 
-        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
-        onClick={handleClose}
-      />
-      
-      {/* 对话框主体 */}
-      <div className="relative bg-white dark:bg-gray-800 rounded-2xl shadow-2xl border border-gray-200 dark:border-gray-700 w-full max-w-md mx-auto transform transition-all">
-        {/* 头部 */}
-        <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
-          <div className="flex items-center space-x-3">
+    <Dialog open={open} onOpenChange={(v) => (v ? onOpenChange(true) : handleClose())}>
+      <DialogContent className="sm:max-w-md p-0" showCloseButton>
+        <DialogHeader className="p-6 border-b border-gray-200 dark:border-gray-700">
+          <div className="flex items-center gap-3">
             <div className="w-10 h-10 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center">
               <Bot className="w-5 h-5 text-white" />
             </div>
             <div>
-              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-                添加智能体
-              </h2>
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                创建一个新的AI助手
-              </p>
+              <DialogTitle className="text-lg text-gray-900 dark:text-white">添加智能体</DialogTitle>
+              <p className="text-sm text-gray-500 dark:text-gray-400">创建一个新的AI助手</p>
             </div>
           </div>
-          
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleClose}
-            disabled={isLoading}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-          >
-            <X className="w-5 h-5" />
-          </Button>
-        </div>
+        </DialogHeader>
 
-        {/* 表单内容 */}
-        <form onSubmit={handleSubmit} className="p-6 space-y-6">
-          {/* 智能体名称 */}
+        <form onSubmit={handleSubmit(onSubmit)} className="p-6 space-y-6">
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              智能体名称 *
-            </label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">智能体名称 *</label>
             <Input
               type="text"
-              value={formData.agentName}
-              onChange={(e) => handleInputChange('agentName', e.target.value)}
+              {...register('agentName')}
+              onCompositionStart={handleCompositionStart}
+              onCompositionEnd={handleCompositionEnd('agentName')}
               placeholder="输入智能体名称"
-              disabled={isLoading}
+              disabled={createMutation.isPending || isSubmitting}
               className="w-full"
-              maxLength={50}
+              // 不使用原生 maxLength，避免 IME 拼音阶段被限制
             />
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              {formData.agentName.length}/50
-            </p>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{(agentName?.length ?? 0)}/{NAME_MAX}</p>
+            {errors.agentName && (
+              <p className="mt-1 text-xs text-destructive">{errors.agentName.message}</p>
+            )}
           </div>
 
-          {/* 智能体描述 */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-              描述 (可选)
-            </label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">描述 (可选)</label>
             <textarea
-              value={formData.description}
-              onChange={(e) => handleInputChange('description', e.target.value)}
+              {...register('description')}
+              onCompositionStart={handleCompositionStart}
+              onCompositionEnd={handleCompositionEnd('description')}
               placeholder="简单描述一下这个智能体的功能..."
-              disabled={isLoading}
+              disabled={createMutation.isPending || isSubmitting}
               className="w-full min-h-[80px] px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
-              maxLength={200}
+              // 不使用原生 maxLength，避免 IME 拼音阶段被限制
             />
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-              {formData.description.length}/200
-            </p>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{(description?.length ?? 0)}/{DESC_MAX}</p>
           </div>
 
-          {/* 错误提示 */}
-          {error && (
+          {submitError && (
             <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
-              <p className="text-sm text-red-600 dark:text-red-400">
-                {error}
-              </p>
+              <p className="text-sm text-red-600 dark:text-red-400">{submitError}</p>
             </div>
           )}
 
-          {/* 按钮组 */}
-          <div className="flex items-center space-x-3 pt-4">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={handleClose}
-              disabled={isLoading}
-              className="flex-1"
-            >
-              取消
-            </Button>
-            <Button
-              type="submit"
-              disabled={isLoading || !formData.agentName.trim()}
-              className="flex-1 bg-blue-600 hover:bg-blue-700 text-white"
-            >
-              {isLoading ? (
-                <>
-                  <div className="w-4 h-4 border-2 border-white/20 border-t-white rounded-full animate-spin mr-2" />
-                  创建中...
-                </>
-              ) : (
-                <>
-                  <Plus className="w-4 h-4 mr-2" />
-                  创建智能体
-                </>
-              )}
-            </Button>
-          </div>
+          <DialogFooter className="p-0">
+            <div className="flex items-center gap-3 w-full">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleClose}
+                disabled={createMutation.isPending || isSubmitting}
+                className="flex-1"
+              >
+                取消
+              </Button>
+              <Button
+                type="submit"
+                disabled={createMutation.isPending || isSubmitting}
+                className="flex-1 bg-blue-600 hover:bg-blue-700 text-white"
+              >
+                {createMutation.isPending || isSubmitting ? (
+                  <>
+                    <div className="w-4 h-4 border-2 border-white/20 border-t-white rounded-full animate-spin mr-2" />
+                    创建中...
+                  </>
+                ) : (
+                  <>
+                    <Plus className="w-4 h-4 mr-2" />
+                    创建智能体
+                  </>
+                )}
+              </Button>
+            </div>
+          </DialogFooter>
         </form>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/main/manager-web-react/src/components/home/AgentCard.tsx
+++ b/main/manager-web-react/src/components/home/AgentCard.tsx
@@ -69,10 +69,10 @@ export function AgentCard({ agent, onConfig, onDelete, onShowChatHistory, onOpen
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.2, ease: 'easeOut' }}
-      className="group relative hover:shadow-lg transition-all duration-200"
+      className="group relative hover:shadow-lg transition-all duration-200 h-full"
       onClick={() => onOpenDetail?.()}
     >
-      <Card className="overflow-hidden">
+      <Card className="overflow-hidden h-full flex flex-col">
 
         <CardHeader className="pb-4">
           <div className="flex items-start gap-3 sm:gap-4">
@@ -97,7 +97,7 @@ export function AgentCard({ agent, onConfig, onDelete, onShowChatHistory, onOpen
           </div>
         </CardHeader>
 
-        <CardContent className="pt-0">
+        <CardContent className="pt-0 flex-1 flex flex-col">
           {/* 次要信息区 */}
           <div className="flex flex-wrap items-center gap-4 mb-4 text-xs text-muted-foreground">
             <div className="flex items-center gap-2">
@@ -135,7 +135,7 @@ export function AgentCard({ agent, onConfig, onDelete, onShowChatHistory, onOpen
 
           {/* 操作区（常显） */}
           <TooltipProvider>
-            <div className={`grid grid-flow-row grid-cols-2 gap-2 opacity-100 translate-y-0`}>
+            <div className={`mt-auto grid grid-flow-row grid-cols-2 gap-2 opacity-100 translate-y-0`}>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button

--- a/main/manager-web-react/src/components/home/AgentGrid.tsx
+++ b/main/manager-web-react/src/components/home/AgentGrid.tsx
@@ -75,13 +75,13 @@ export function AgentGrid({
 
   return (
     <div className="pt-6 sm:pt-8">
-      {/* 瀑布流容器：CSS 多列布局 */}
-      <div className="columns-1 sm:columns-2 lg:columns-3 xl:columns-4 gap-x-4 sm:gap-x-6">
+      {/* 网格容器：标准 CSS Grid 四列布局，避免瀑布流产生的空列 */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6">
         {/* 加载状态：显示骨架屏 */}
         {isLoading && (
           <>
             {Array.from({ length: skeletonCount }).map((_, index) => (
-              <div key={`skeleton-${index}`} className="break-inside-avoid mb-4 sm:mb-6">
+              <div key={`skeleton-${index}`} className="h-full">
                 <SkeletonCard />
               </div>
             ))}
@@ -92,7 +92,7 @@ export function AgentGrid({
         {!isLoading && (
           <AnimatePresence initial={false}>
             {agents.map((agent) => (
-              <div key={agent.id} className="break-inside-avoid mb-4 sm:mb-6">
+              <div key={agent.id} className="h-full">
                 <AgentCard
                   agent={agent}
                   onConfig={() => onAgentConfig(agent.id)}

--- a/main/manager-web-react/src/components/home/SkeletonCard.tsx
+++ b/main/manager-web-react/src/components/home/SkeletonCard.tsx
@@ -11,9 +11,9 @@ export interface SkeletonCardProps {}
  */
 export function SkeletonCard({}: SkeletonCardProps) {
   return (
-    <div className="relative bg-card rounded-xl shadow-sm border border-border overflow-hidden animate-pulse">
+    <div className="relative bg-card rounded-xl shadow-sm border border-border overflow-hidden animate-pulse h-full flex flex-col">
 
-      <div className="p-6">
+      <div className="p-6 flex-1 flex flex-col">
         {/* 头部：基本信息（移除头像骨架） */}
         <div className="flex items-start justify-between mb-4">
           {/* 信息骨架 */}
@@ -39,7 +39,7 @@ export function SkeletonCard({}: SkeletonCardProps) {
         </div>
 
         {/* 操作按钮骨架 */}
-        <div className="flex items-center space-x-2">
+        <div className="mt-auto flex items-center space-x-2">
           <div className="flex-1 h-8 bg-muted rounded-md"></div>
           <div className="flex-1 h-8 bg-muted rounded-md"></div>
           <div className="w-8 h-8 bg-muted rounded-md"></div>

--- a/main/manager-web-react/src/components/layout/MobileSidebar.tsx
+++ b/main/manager-web-react/src/components/layout/MobileSidebar.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { useLocation, NavLink } from 'react-router-dom'
+import { NavLink } from 'react-router-dom'
 import { X } from 'lucide-react'
-import { navItems } from './Sidebar'
+import { navItems } from './navigation'
 import { cn } from '@/lib/utils'
 import { ThemeToggle } from '@/components/ui/theme-toggle'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -13,9 +13,8 @@ interface MobileSidebarProps {
 }
 
 export function MobileSidebar({ open, onClose }: MobileSidebarProps) {
-  const location = useLocation()
   const { publicConfig } = useAuth()
-  const homeConfig = (publicConfig?.homeConfig || {}) as Record<string, any>
+  const homeConfig = (publicConfig?.homeConfig || {}) as Record<string, unknown>
   const platformSubTitle = (homeConfig.platformSubTitle || '管理平台') as string
 
   return (
@@ -59,26 +58,35 @@ export function MobileSidebar({ open, onClose }: MobileSidebarProps) {
               </div>
             </div>
 
-            <nav className="p-2 space-y-1 overflow-y-auto">
-              {navItems.map((item) => {
-                const active = location.pathname === item.to
-                return (
-                  <NavLink
-                    key={item.to}
-                    to={item.to}
-                    onClick={onClose}
-                    className={cn(
-                      'group flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors',
-                      active
-                        ? 'bg-blue-600 text-white'
-                        : 'text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800'
-                    )}
-                  >
-                    <span className={cn('text-gray-500 group-hover:text-current', active && 'text-white')}>{item.icon}</span>
-                    <span className="truncate">{item.label}</span>
-                  </NavLink>
-                )
-              })}
+            <nav className="p-2 space-y-0.5 overflow-y-auto">
+              {navItems.map((item) => (
+                <NavLink
+                  key={`${item.to}-${item.label}`}
+                  to={item.to}
+                  onClick={onClose}
+                  className={({ isActive }) =>
+                    cn(
+                      'group relative flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors overflow-hidden',
+                      isActive ? 'text-primary-foreground' : 'text-muted-foreground hover:bg-muted'
+                    )
+                  }
+                  end={item.to === '/home'}
+                >
+                  {({ isActive }) => (
+                    <>
+                      {isActive && (
+                        <motion.span
+                          layoutId="sidebar-active-bg"
+                          className="absolute inset-0 rounded-md bg-primary"
+                          transition={{ type: 'spring', stiffness: 500, damping: 38 }}
+                        />
+                      )}
+                      <span className={cn('relative z-10 text-muted-foreground group-hover:text-foreground', isActive && 'text-primary-foreground')}>{item.icon}</span>
+                      <span className="relative z-10 truncate">{item.label}</span>
+                    </>
+                  )}
+                </NavLink>
+              ))}
             </nav>
           </motion.aside>
         </motion.div>

--- a/main/manager-web-react/src/components/layout/Sidebar.tsx
+++ b/main/manager-web-react/src/components/layout/Sidebar.tsx
@@ -1,32 +1,17 @@
 import React from "react";
-import { NavLink, useLocation } from "react-router-dom";
-import { Home, Bot, Wrench, Package, SlidersHorizontal, BookText, PanelLeft } from "lucide-react";
+import { NavLink } from "react-router-dom";
 import { cn } from "@/lib/utils";
 // 移除品牌图片，遵循不出现特定品牌字样与图片的约束
 import { ThemeToggle } from "@/components/ui/theme-toggle";
 import { useAuth } from "@/contexts/AuthContext";
+import { motion } from "framer-motion";
+import { navItems } from "./navigation";
 
-export interface NavItem {
-  label: string;
-  to: string;
-  icon: React.ReactNode;
-}
-
-export const navItems: NavItem[] = [
-  { label: "概览", to: "/home", icon: <Home className="w-4 h-4" /> },
-  { label: "我的智能体", to: "/home", icon: <Bot className="w-4 h-4" /> },
-  // { label: '设备工具', to: '/device-tools/activation', icon: <Wrench className="w-4 h-4" /> },
-  { label: "OTA 固件", to: "/ota-management", icon: <Package className="w-4 h-4" /> },
-  { label: "模型配置", to: "/model-management", icon: <PanelLeft className="w-4 h-4" /> },
-  { label: "字段管理", to: "/provider-management", icon: <PanelLeft className="w-4 h-4" /> },
-  { label: "参数管理", to: "/params", icon: <SlidersHorizontal className="w-4 h-4" /> },
-  { label: "字典管理", to: "/dict-management", icon: <BookText className="w-4 h-4" /> },
-];
+// 导航配置移至独立文件，避免与组件同文件导出导致 Fast Refresh 限制
 
 export function Sidebar() {
-  const location = useLocation();
   const { publicConfig } = useAuth();
-  const homeConfig = (publicConfig?.homeConfig || {}) as Record<string, any>;
+  const homeConfig = (publicConfig?.homeConfig || {}) as Record<string, unknown>;
   const platformSubTitle = (homeConfig.platformSubTitle || "管理平台") as string;
 
   return (
@@ -40,25 +25,34 @@ export function Sidebar() {
       </div>
 
       {/* Navigation */}
-      <nav className="p-2 space-y-1 overflow-y-auto">
-        {navItems.map((item) => {
-          const active = location.pathname === item.to;
-          return (
-            <NavLink
-              key={`${item.to}-${item.label}`}
-              to={item.to}
-              className={cn(
-                "group flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors",
-                active
-                  ? "bg-blue-600 text-white"
-                  : "text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
-              )}
-            >
-              <span className={cn("text-gray-500 group-hover:text-current", active && "text-white")}>{item.icon}</span>
-              <span className="truncate">{item.label}</span>
-            </NavLink>
-          );
-        })}
+      <nav className="p-2 space-y-0.5 overflow-y-auto">
+        {navItems.map((item) => (
+          <NavLink
+            key={`${item.to}-${item.label}`}
+            to={item.to}
+            className={({ isActive }) =>
+              cn(
+                "group relative flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors overflow-hidden",
+                isActive ? "text-primary-foreground" : "text-muted-foreground hover:bg-muted"
+              )
+            }
+            end={item.to === "/home"}
+          >
+            {({ isActive }) => (
+              <>
+                {isActive && (
+                  <motion.span
+                    layoutId="sidebar-active-bg"
+                    className="absolute inset-0 rounded-md bg-primary"
+                    transition={{ type: "spring", stiffness: 500, damping: 38 }}
+                  />
+                )}
+                <span className={cn("relative z-10 text-muted-foreground group-hover:text-foreground", isActive && "text-primary-foreground")}>{item.icon}</span>
+                <span className="relative z-10 truncate">{item.label}</span>
+              </>
+            )}
+          </NavLink>
+        ))}
       </nav>
 
       {/* Footer spacer */}

--- a/main/manager-web-react/src/components/layout/UserMenu.tsx
+++ b/main/manager-web-react/src/components/layout/UserMenu.tsx
@@ -58,7 +58,7 @@ export function UserMenu({ compact = false }: UserMenuProps) {
       {trigger}
       {menuOpen && (
         <div className="absolute right-0 mt-2 z-50 w-40 rounded-md border bg-popover text-popover-foreground shadow-md">
-          <div className="px-3 py-2 text-xs text-muted-foreground">{state.user?.username || '未登录'}</div>
+          <div className="px-3 py-2 text-xs text-muted-foreground">{state.isAuthenticated ? (state.user?.username || '已登录') : '未登录'}</div>
           <div className="py-1">
             <button
               className="w-full px-3 py-2 text-sm flex items-center gap-2 hover:bg-muted"

--- a/main/manager-web-react/src/components/layout/navigation.tsx
+++ b/main/manager-web-react/src/components/layout/navigation.tsx
@@ -1,0 +1,28 @@
+/*
+ * @Author: yuyuhailian 1411102347@qq.com
+ * @Date: 2025-09-29 16:04:21
+ * @LastEditors: yuyuhailian 1411102347@qq.com
+ * @LastEditTime: 2025-09-29 16:05:05
+ * @FilePath: \manager-web-react\src\components\layout\navigation.tsx
+ * @Description: 这是默认设置,请设置`customMade`, 打开koroFileHeader查看配置 进行设置: https://github.com/OBKoro1/koro1FileHeader/wiki/%E9%85%8D%E7%BD%AE
+ */
+import React from "react";
+import { Home, Package, SlidersHorizontal, BookText, PanelLeft } from "lucide-react";
+
+export interface NavItem {
+  label: string;
+  to: string;
+  icon: React.ReactNode;
+}
+
+export const navItems: NavItem[] = [
+  { label: "概览", to: "/home", icon: <Home className="w-4 h-4" /> },
+  // { label: '设备工具', to: '/device-tools/activation', icon: <Wrench className="w-4 h-4" /> },
+  { label: "OTA 固件", to: "/ota-management", icon: <Package className="w-4 h-4" /> },
+  { label: "模型配置", to: "/model-management", icon: <PanelLeft className="w-4 h-4" /> },
+  { label: "字段管理", to: "/provider-management", icon: <PanelLeft className="w-4 h-4" /> },
+  { label: "参数管理", to: "/params", icon: <SlidersHorizontal className="w-4 h-4" /> },
+  { label: "字典管理", to: "/dict-management", icon: <BookText className="w-4 h-4" /> },
+];
+
+

--- a/main/manager-web-react/src/pages/ModelConfig.tsx
+++ b/main/manager-web-react/src/pages/ModelConfig.tsx
@@ -357,6 +357,10 @@ export function ModelConfigPage() {
   const type = searchParams.get('type') || 'llm'
   const q = searchParams.get('q') || ''
 
+  // 使用本地受控输入，避免每次按键就改 URL 导致重新渲染与截断
+  const [localQ, setLocalQ] = React.useState(q)
+  React.useEffect(() => { setLocalQ(q) }, [q])
+
   const { currentPage, pageSize, setPageSize, pageSizeOptions, goFirst, goPrev, goNext, goToPage, visiblePages, pageCount, setTotal } = usePagination(10)
 
   const { data, isLoading, refetch } = useModelsListGetModelConfigListQuery(
@@ -376,11 +380,10 @@ export function ModelConfigPage() {
     setSearchParams((prev) => {
       const n = new URLSearchParams(prev)
       n.set('type', type)
-      if (q) n.set('q', q)
+      if (localQ) n.set('q', localQ)
       else n.delete('q')
       return n
     })
-    refetch()
   }
 
   const handleToggle = async (id: string | number, enabled: boolean) => {
@@ -449,8 +452,8 @@ export function ModelConfigPage() {
         <div className="flex items-stretch gap-2">
           <Input
             placeholder="按名称搜索"
-            defaultValue={q}
-            onChange={(e) => setSearchParams((prev) => { const n = new URLSearchParams(prev); if (e.target.value) n.set('q', e.target.value); else n.delete('q'); return n })}
+            value={localQ}
+            onChange={(e) => setLocalQ(e.target.value)}
             onKeyDown={(e) => { if (e.key === 'Enter') handleSearch() }}
           />
           <Button variant="outline" onClick={handleSearch}>搜索</Button>

--- a/main/manager-web-react/vite.config.ts
+++ b/main/manager-web-react/vite.config.ts
@@ -18,6 +18,10 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ""), // 可选：把 /api 去掉，只留后面的路径
       },
+      "/user": {
+        target: "http://localhost:8002/xiaozhi",
+        changeOrigin: true,
+      },
     },
   },
 });


### PR DESCRIPTION
首页登录注册
底部出现不明字段显示
错误信息未正确渲染
点击验证码即出现“登录中...”，未输入账号密码也进入登录态提示
概览/我的智能体
“立即开始/添加智能体”均跳同一弹窗的交互确认
添加智能体描述输入时拼音被限制为 20 长度
弹窗打开时发生滚动穿透
系统提示词无字数上限
总结记忆无字数上限，导致页面无限延展
详情编辑保存后未跳转回智能体列表
智能体卡片四列布局在数量较多时出现空列
排序权重保存提示成功，但重新进入数据未持久
新建智能体未做名称重复校验
模型配置
搜索框输入 1 个字符后即被截断并自动搜索
搜索仅支持英文，无法输入/拼写中文
字段管理
供应器名称为英文时，搜索失效
参数管理
新建参数的 id 位数与现有数据不一致
搜索框无法输入中文，且逐字被截断并立即触发搜索
字典管理
搜索框在输入中即读取全文并自动搜索，应改为回车/点击触发或防抖
新增字典类型备注无限长，区域高度不足导致不可读
字典编码无长度限制，过长创建失败但无任何提示
字典名称无长度限制且单行显示
字典数据未做文本限制
字典数据删除成功无提示；字典类型删除成功无提示
修改左侧字典类型名后，右侧字典数据管理名称未同步
新增字典数据：只填“标签”不填“值”时创建按钮未置灰，提交失败亦无提示
编辑字典数据：排序改为负数保存失败无提示，重新打开仍是旧值
需要优化左侧菜单点击与布局表现